### PR TITLE
[vim] refactor vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,23 +114,20 @@ tmuxinator new [arbitrary name]
 
 ## Vim
 
+- [vim-plug](https://github.com/junegunn/vim-plug#vim)
+
 ```sh
 # for 'deoplete.nvim'
 brew install vim --with-lua --with-python3
-pip3 install neovim
 
-ln -s ~/dotfiles/vim/vimrc ~/.vimrc
-ln -s ~/dotfiles/vim/gvimrc ~/.gvimrc
+ln -s ~/dotfiles/vim ~/.vim
 
-ln -s ~/dotfiles/vim/git-commit-editor ~/.git-commit-editor
+vim +PlugInstall +qall
 ```
 
-Then run `vim +PlugInstall +qall` in Vim
+### Neovim
 
-### Neovim 
-
-- [Homebrew version](https://github.com/neovim/homebrew-neovim/blob/master/README.md)
-- [vim-plug setup](https://github.com/junegunn/vim-plug#neovim)
+- [vim-plug](https://github.com/junegunn/vim-plug#neovim)
 
 To use the same configuration as Vim:
 
@@ -139,9 +136,15 @@ To use the same configuration as Vim:
 #'.config/' may not exist, `mkdir ~/.config`
 ln -s ~/.vim ~/.config/nvim
 
-ln -s ~/.vimrc ~/.config/nvim/init.vim
+ln -s ~/.vim/vimrc ~/.config/nvim/init.vim
 
-pip install [--user] neovim
+nvim +PlugInstall +UpdateRemotePlugins +qa
+```
+
+```sh
+pip[3] install [--user] pynvim
+npm i -g neovim
+gem install neovim
 ```
 
 ## Miscs.

--- a/vim/after/ftplugin/css.vim
+++ b/vim/after/ftplugin/css.vim
@@ -1,0 +1,2 @@
+" Plugin: vim-css3-syntax
+setlocal iskeyword+=-

--- a/vim/after/ftplugin/git.vim
+++ b/vim/after/ftplugin/git.vim
@@ -1,0 +1,2 @@
+" commit message
+setlocal spell textwidth=72

--- a/vim/after/ftplugin/go.vim
+++ b/vim/after/ftplugin/go.vim
@@ -1,0 +1,69 @@
+" writes the content of the file automatically if you call :make
+set autowrite
+
+map <C-n> :cnext<CR>
+map <C-m> :cprevious<CR>
+nnoremap <leader>a :cclose<CR>
+
+" vim-go {{{
+" :GoSameIds, identifier highlighting
+let g:go_auto_sameids        = 1
+
+" :GoInfo, <Plug>(go-info)
+let g:go_auto_type_info      = 1
+
+" instead of invoking :GoImports manually
+" might be slow on very large codebases
+let g:go_fmt_command         = 'goimports'
+
+let g:go_metalinter_autosave = 1
+
+" mappings {{{2
+" :GoBuild
+nmap <leader>gob :<C-u>call <SID>build_go_files()<CR>
+nmap <leader>gor <Plug>(go-run)
+nmap <leader>got <Plug>(go-test)
+" :GoCoverageToggle
+nmap <Leader>goc <Plug>(go-coverage-toggle)
+
+" run :GoBuild or :GoTestCompile based on the go file
+function! s:build_go_files()
+  let l:file = expand('%')
+  if l:file =~# '^\f\+_test\.go$'
+    call go#test#Test(0, 1)
+  elseif l:file =~# '^\f\+\.go$'
+    call go#cmd#Build(0)
+  endif
+endfunction
+" }}}2
+" commands {{{2
+" opens the alternate file
+command! -bang A call go#alternate#Switch(<bang>0, 'edit')
+command! -bang AV call go#alternate#Switch(<bang>0, 'vsplit')
+command! -bang AS call go#alternate#Switch(<bang>0, 'split')
+command! -bang AT call go#alternate#Switch(<bang>0, 'tabe')
+" }}}2
+" highlight {{{2
+" :h go-settings
+let g:go_highlight_types             = 1
+let g:go_highlight_fields            = 1
+let g:go_highlight_functions         = 1
+let g:go_highlight_function_calls    = 1
+let g:go_highlight_operators         = 1
+let g:go_highlight_extra_types       = 1
+let g:go_highlight_build_constraints = 1
+let g:go_highlight_generate_tags     = 1
+" }}}2
+" }}}
+" deoplete-go {{{
+" https://github.com/deoplete-plugins/deoplete-go#sample-initvim
+"
+" neocomplete like
+set completeopt+=noinsert
+" deoplete.nvim recommend
+set completeopt+=noselect
+
+" deoplete-go settings
+let g:deoplete#sources#go#gocode_binary = $HOME.'go/bin/gocode'
+let g:deoplete#sources#go#sort_class = ['package', 'func', 'type', 'var', 'const']
+" }}}

--- a/vim/after/ftplugin/html.vim
+++ b/vim/after/ftplugin/html.vim
@@ -1,0 +1,4 @@
+" Plugin: vim-dispatch
+"
+" TODO make this independent of platform
+let b:dispatch = '!open %:p'

--- a/vim/after/ftplugin/javascript.vim
+++ b/vim/after/ftplugin/javascript.vim
@@ -1,0 +1,19 @@
+" Plugin: indentLine {{{
+let g:indentLine_conceallevel = 1
+" }}}
+" Plugin: vim-javascript {{{
+let g:javascript_conceal_function   = 'ƒ'
+let g:javascript_conceal_null       = 'ø'
+let g:javascript_conceal_this       = '@'
+let g:javascript_conceal_return     = '⇚'
+let g:javascript_conceal_undefined  = '¿'
+let g:javascript_conceal_NaN        = 'ℕ'
+let g:javascript_conceal_prototype  = '¶'
+let g:javascript_conceal_static     = '•'
+let g:javascript_conceal_super      = 'Ω'
+" }}}
+" Plugin: vim-jsdoc {{{
+let g:jsdoc_allow_input_prompt = 1
+" reserve <C-l> for the mapping used by 'vim-tmux-navigator'
+let g:jsdoc_default_mapping    = 0
+" }}}

--- a/vim/after/ftplugin/scss.vim
+++ b/vim/after/ftplugin/scss.vim
@@ -1,0 +1,2 @@
+" scss-syntax.vim
+setlocal iskeyword+=-

--- a/vim/after/ftplugin/vim.vim
+++ b/vim/after/ftplugin/vim.vim
@@ -1,0 +1,1 @@
+setlocal foldmethod=marker

--- a/vim/after/ftplugin/xml.vim
+++ b/vim/after/ftplugin/xml.vim
@@ -1,0 +1,3 @@
+setlocal foldmethod=syntax
+
+let g:xml_syntax_folding = 1

--- a/vim/ftdetect/ag.vim
+++ b/vim/ftdetect/ag.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead .ignore,.agignore setlocal commentstring=#\ %s

--- a/vim/ftdetect/docker.vim
+++ b/vim/ftdetect/docker.vim
@@ -1,0 +1,2 @@
+" reference: https://github.com/docker/docker/blob/master/contrib/syntax/vim/ftdetect/dockerfile.vim
+autocmd BufNewFile,BufRead [Dd]ockerfile,Dockerfile.* set filetype=dockerfile

--- a/vim/ftdetect/md.vim
+++ b/vim/ftdetect/md.vim
@@ -1,0 +1,7 @@
+" force *.md as MarkDown, https://github.com/tpope/vim-markdown
+autocmd BufNewFile,BufReadPost *.md set filetype=markdown
+
+let g:markdown_fenced_languages = ['html', 'json', 'python', 'scss', 'sh', 'sql', 'yaml']
+
+" https://github.com/previm/previm 
+nnoremap <silent> <leader>pv :PrevimOpen<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1,5 +1,3 @@
-" vim:fdm=marker
-
 let s:darwin = has('mac')
 
 set nocompatible
@@ -164,11 +162,12 @@ Plug 'junegunn/vim-emoji'
 Plug 'kannokanno/previm'
 Plug 'keith/investigate.vim'
 Plug 'kshenoy/vim-signature'
-Plug 'machakann/vim-swap'
+" Plug 'machakann/vim-swap'
 Plug 'mattn/emmet-vim'
 Plug 'mbbill/undotree'
 Plug 'mhinz/vim-grepper', { 'on': ['Grepper', '<plug>(GrepperOperator)'] }
 Plug 'othree/html5.vim'
+" Plug 'Shougo/echodoc.vim'
 Plug 'scrooloose/nerdtree'
 Plug 'terryma/vim-expand-region'
 Plug 'tommcdo/vim-exchange'
@@ -240,6 +239,8 @@ Plug 'hail2u/vim-css3-syntax'
 " }}}
 " Go {{{
 Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
+" https://github.com/deoplete-plugins/deoplete-go#4-install-plugin-and-build-ujson-module
+Plug 'zchee/deoplete-go', { 'do': 'make'}
 " }}}
 " JavaScript {{{
 Plug 'heavenshell/vim-jsdoc', { 'for': 'javascript' }
@@ -362,17 +363,8 @@ let g:netrw_nogx = 1 " disable netrw's gx mapping.
 nmap gx <Plug>(openbrowser-smart-search)
 vmap gx <Plug>(openbrowser-smart-search)
 " }}}
-" Plugin: previm {{{
-nnoremap <silent> <leader>pv :PrevimOpen<CR>
-" }}}
 " Plugin: quick-scope {{{
 let g:qs_highlight_on_keys = ['f', 'F', 't', 'T']
-" }}}
-" Plugin: scss-syntax.vim {{{
-augroup scss-syntax.vim
-  autocmd!
-  autocmd FileType scss setlocal iskeyword+=-
-augroup END
 " }}}
 " Plugin: tagbar {{{
 nmap <F8> :TagbarToggle<CR>
@@ -423,15 +415,7 @@ map gz* <Plug>(asterisk-gz*)
 map z#  <Plug>(asterisk-z#)
 map gz# <Plug>(asterisk-gz#)
 " }}}
-" Plugin: vim-css3-syntax {{{
-augroup vim-css3-syntax
-  autocmd!
-  " Plugin: vim-css3-syntax
-  autocmd FileType css setlocal iskeyword+=-
-augroup END
-" }}}
 " Plugin: vim-dispatch {{{
-autocmd FileType html let b:dispatch = '!open %:p'
 nnoremap <F9> :Dispatch<CR>
 " }}}
 " Plugin: vim-easy-align {{{
@@ -458,43 +442,6 @@ vmap <C-v> <Plug>(expand_region_shrink)
 nmap <leader>gb :Gblame<cr>
 nmap <leader>gs :Gstatus<cr>
 " }}}
-" Plugin: vim-go {{{
-" instead of invoking :GoImports manually
-" let g:go_fmt_command = "goimports"
-" :GoInfo
-let g:go_auto_type_info = 1
-" :GoSameIds
-let g:go_auto_sameids = 1
-
-" run :GoBuild or :GoTestCompile based on the go file
-function! s:build_go_files()
-  let l:file = expand('%')
-  if l:file =~# '^\f\+_test\.go$'
-    call go#test#Test(0, 1)
-  elseif l:file =~# '^\f\+\.go$'
-    call go#cmd#Build(0)
-  endif
-endfunction
-
-augroup go
-  autocmd!
-  autocmd FileType go setlocal updatetime=800
-  " :GoBuild
-  " autocmd FileType go nmap <leader>gob <Plug>(go-build)
-  autocmd FileType go nmap <leader>gob :<C-u>call <SID>build_go_files()<CR>
-  autocmd FileType go nmap <leader>gor <Plug>(go-run)
-  autocmd FileType go nmap <leader>got <Plug>(go-test)
-  " :GoCoverageToggle
-  autocmd FileType go nmap <Leader>goc <Plug>(go-coverage-toggle)
-  " opens the alternate file
-  autocmd Filetype go command! -bang A call go#alternate#Switch(<bang>0, 'edit')
-  autocmd Filetype go command! -bang AV call go#alternate#Switch(<bang>0, 'vsplit')
-  autocmd Filetype go command! -bang AS call go#alternate#Switch(<bang>0, 'split')
-  autocmd Filetype go command! -bang AT call go#alternate#Switch(<bang>0, 'tabe')
-  " :GoInfo
-  " autocmd FileType go nmap <Leader>goi <Plug>(go-info)
-augroup END
-" }}}
 " Plugin: vim-grepper {{{
 if executable('ag')
   nnoremap <leader>ag :Grepper -tool ag -highlight<cr>
@@ -503,22 +450,6 @@ if executable('ag')
 endif
 nmap gs <plug>(GrepperOperator)
 xmap gs <plug>(GrepperOperator)
-" }}}
-" Plugin: vim-javascript {{{
-let g:javascript_conceal_function   = 'ƒ'
-let g:javascript_conceal_null       = 'ø'
-let g:javascript_conceal_this       = '@'
-let g:javascript_conceal_return     = '⇚'
-let g:javascript_conceal_undefined  = '¿'
-let g:javascript_conceal_NaN        = 'ℕ'
-let g:javascript_conceal_prototype  = '¶'
-let g:javascript_conceal_static     = '•'
-let g:javascript_conceal_super      = 'Ω'
-" }}}
-" Plugin: vim-jsdoc {{{
-let g:jsdoc_allow_input_prompt = 1
-" reserve <C-l> for the mapping used by 'vim-tmux-navigator'
-let g:jsdoc_default_mapping    = 0
 " }}}
 " Plugin: vim-localvimrc {{{
 " https://github.com/embear/vim-localvimrc#the-glocalvimrc_persistent-setting
@@ -552,45 +483,10 @@ map <Leader>vl :VimuxRunLastCommand<CR>
 map <Leader>vi :VimuxInspectRunner<CR>
 " }}}
 " Autocommands {{{1
-augroup ag " {{{2
-  autocmd!
-  autocmd BufNewFile,BufReadPost .agignore setlocal commentstring=#\ %s
-augroup END " }}} 2
 augroup autoSaveAndRead " {{{2
   autocmd!
   autocmd TextChanged,InsertLeave,FocusLost * silent! wall
   autocmd CursorHold * silent! checktime
-augroup END " }}} 2
-augroup docker " {{{2
-  autocmd!
-  " reference: https://github.com/docker/docker/blob/master/contrib/syntax/vim/ftdetect/dockerfile.vim
-  autocmd BufNewFile,BufRead [Dd]ockerfile,Dockerfile.* set filetype=dockerfile
-augroup END " }}}2
-augroup git " {{{2
-  autocmd!
-  " commit message
-  autocmd FileType gitcommit setlocal spell textwidth=72
-augroup END " }}}2
-augroup javascript " {{{2
-  autocmd!
-  " for '/tpope/vim-commentary' on JSX
-  autocmd FileType javascript.jsx setlocal commentstring={/*\ %s\ */}
-augroup END " }}} 2
-augroup json " {{{2
-  autocmd!
-  autocmd BufRead,BufNewFile .bowerrc setlocal ft=json
-augroup END " }}} 2
-augroup markdown " {{{2
-  autocmd!
-  " force *.md as MarkDown, https://github.com/tpope/vim-markdown
-  autocmd BufNewFile,BufReadPost *.md set filetype=markdown
-  " highlight markdown fenced code syntax
-  let g:markdown_fenced_languages = ['html', 'json', 'python', 'scss', 'sh', 'sql', 'yaml']
-augroup END " }}}2
-augroup xml " {{{2
-  autocmd!
-  autocmd FileType xml setlocal foldmethod=syntax
-  let g:xml_syntax_folding=1
 augroup END " }}} 2
 " }}}1
 " Neovim-specific {{{


### PR DESCRIPTION
Install `golint-ci`, `goimports`, `gocode` (github.com/stamblerre/gocode).

See:

- https://vimways.org/2018/from-vimrc-to-vim/
- https://github.com/golangci/golangci-lint#go-get
- https://godoc.org/golang.org/x/tools/cmd/goimports
- https://github.com/stamblerre/gocode
- https://github.com/deoplete-plugins/deoplete-go#sample-initvim